### PR TITLE
bump IDA version support to 9.3

### DIFF
--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -8,7 +8,8 @@
     "idaVersions": [
       "9.0",
       "9.1",
-      "9.2"
+      "9.2",
+      "9.3"
     ],
     "description": "A lightweight terminal integration for IDA Pro that lets you open a fully functional terminal within the IDA GUI.\nQuickly access shell commands, scripts, or tooling without leaving your reversing environment.",
     "license": "MIT",


### PR DESCRIPTION
Hi maintainers,

`ida-terminal-plugin` seem's to work just fine on IDA 9.3, but it was not installable through `hcli` because of version checks.

This PR, just bump the version.

(not tested on Windows)